### PR TITLE
Add support for setting display text

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ This command sets the current limit of the running charging process.
 Parameters:
 - current in ampere (default = 0 A)
 
+### set_text
+This command displays a text on the display of the charger.
+
+Parameters:
+- text to show on the display
+- min time to show the text before next text is shown (default = 2 s)
+- max time to show the text (default = 10 s)
+
 ### start
 This command authorizes a charging process with the given RFID tag and RFID class.
 

--- a/keba_kecontact/connection.py
+++ b/keba_kecontact/connection.py
@@ -109,6 +109,9 @@ class KebaKeContact:
         if not isinstance(mintime, (int, float)) or not isinstance(maxtime, (int, float)):
             raise ValueError("Times must be int or float.")
 
+        if mintime < 0 or mintime > 65535 or maxtime < 0 or maxtime > 65535:
+            raise ValueError("Times must be between 0 and 65535")
+
         self.keba_protocol.send("display 1 " + str(int(round(mintime))) + ' ' + str(int(round(maxtime))) + " 0 " + text[0:23])
         await asyncio.sleep(0.1)  # Sleep for 100 ms as given in the manual
 

--- a/keba_kecontact/connection.py
+++ b/keba_kecontact/connection.py
@@ -101,6 +101,17 @@ class KebaKeContact:
         self.keba_protocol.send('currtime ' + str(current * 1000) + ' 1')
         await asyncio.sleep(0.1)  # Sleep for 100 ms as given in the manual
 
+    async def set_text(self, text, mintime=2, maxtime=10):
+        """Show a text on the display."""
+        if not self._setup:
+            await self.setup()
+
+        if not isinstance(mintime, (int, float)) or not isinstance(maxtime, (int, float)):
+            raise ValueError("Times must be int or float.")
+
+        self.keba_protocol.send("display 1 " + str(int(round(mintime))) + ' ' + str(int(round(maxtime))) + " 0 " + text[0:23])
+        await asyncio.sleep(0.1)  # Sleep for 100 ms as given in the manual
+
     async def start(self, rfid, rfid_class="01010400000000000000"):  # Default color white
         """Authorize a charging process with predefined RFID tag."""
         if not self._setup:

--- a/keba_kecontact/keba_protocol.py
+++ b/keba_kecontact/keba_protocol.py
@@ -127,4 +127,4 @@ class KebaProtocol(asyncio.DatagramProtocol):
     def send(self, payload):
         """Send data to KEBA charging station."""
         _LOGGER.debug("Send %s", payload)
-        self._transport.sendto(payload.encode())
+        self._transport.sendto(payload.encode('cp437', 'ignore'))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="keba_kecontact",
-    version="1.0.0",
+    version="1.1.0",
     author="Philipp Danner",
     author_email="philipp@danner-web.de",
     description="A python library to communicate with the KEBA charging stations via udp",


### PR DESCRIPTION
Adds a new command, set_text(), which will output a text message on the display. 

The API call contains a parameter to select if the supplied min/max times should be used, or if the default of 2/10 should be used. I didn't see any reason for including this parameter.

The character set of the display is not documented, but it seems like it is CP437 or similar. As far as I can tell, it should be OK to always convert data sent to the charger to CP437. 

