### PR TITLE
Report total energy consumption with 2 decimals

### DIFF
--- a/keba_kecontact/keba_protocol.py
+++ b/keba_kecontact/keba_protocol.py
@@ -112,7 +112,7 @@ class KebaProtocol(asyncio.DatagramProtocol):
                     json_rcv['P'] = round(json_rcv['P'] / 1000000.0, 2)
                     json_rcv['PF'] = json_rcv['PF'] / 1000.0
                     json_rcv['E pres'] = round(json_rcv['E pres'] / 10000.0, 2)
-                    json_rcv['E total'] = int(json_rcv['E total'] / 10000)
+                    json_rcv['E total'] = round(json_rcv['E total'] / 10000.0, 2)
                     self.data.update(json_rcv)
                 except KeyError:
                     _LOGGER.warning("Could not extract report 3 data for KEBA charging station")


### PR DESCRIPTION
In the [documentation of Keba P30](https://www.keba.com/download/x/4a925c4c61/kecontactp30udp_pgen.pdf) the value "E total" is described as 

> Total energy consumption (persistent, device related) in 0.1 Wh. Max. value is 99999999.9 Wh higher values will cause a counter overflow).

Rounding to two decimals makes sense, since other parsed values (e.g. "E Pres", "P") get reported with the same accuracy.
