### PR TITLE
Remove rounding

### DIFF
--- a/keba_kecontact/__init__.py
+++ b/keba_kecontact/__init__.py
@@ -1,6 +1,6 @@
 """Init file for keba_kecontact."""
 
-__version__ = "4.3.0"
+__version__ = "4.3.1"
 
 import asyncio
 

--- a/keba_kecontact/charging_station.py
+++ b/keba_kecontact/charging_station.py
@@ -131,7 +131,7 @@ class ChargingStation:
             ReportField.E_START,
         ]
         for k in ten_thousands:
-            json_rcv[k] = round(json_rcv[k] / 10000.0, 2)
+            json_rcv[k] = json_rcv[k] / 10000.0
 
         # Extract plug state
         if ReportField.PLUG in json_rcv:
@@ -160,7 +160,7 @@ class ChargingStation:
             json_rcv[ReportField.FS_ON] = json_rcv[ReportField.TMO_FS] > 0
 
         if ReportField.P in json_rcv:
-            json_rcv[ReportField.P] = round(json_rcv[ReportField.P] / 1000000.0, 2)
+            json_rcv[ReportField.P] = json_rcv[ReportField.P] / 1000000.0
 
         # Cleanup invalid values
         if ReportField.CURR_HW in json_rcv and json_rcv[ReportField.CURR_HW] == 0:


### PR DESCRIPTION
Thanks for reviewing this PR. I wanted to add a bit more context about why removing the rounding is important.

The KEBA charger reports energy values with higher precision (e.g., 195.4423). The current implementation rounds these values inside the library before returning them. This causes issues for Home Assistant and other consumers that expect raw device data.

Home Assistant applies its own rounding and formatting rules based on device class, state class, and unit of measurement. When the library rounds prematurely, HA loses precision and cannot apply its own logic correctly.

By returning the raw values from the device, the library becomes more accurate and more flexible, and downstream integrations can handle presentation as intended.

Let me know if you’d like any adjustments.